### PR TITLE
feat(plugin): Update FileSystemViewer UI top-row button redesign

### DIFF
--- a/src/plugins/bdCompatLayer/fileSystemViewer.tsx
+++ b/src/plugins/bdCompatLayer/fileSystemViewer.tsx
@@ -19,7 +19,7 @@
 import { classNameFactory } from "@api/Styles";
 import { SettingsTab, wrapTab } from "@components/VencordSettings/shared";
 import { Plugin } from "@utils/types";
-import { Button, Card, Forms, React, useRef } from "@webpack/common";
+import { Card, Forms, React, useRef } from "@webpack/common";
 
 import { PLUGIN_NAME } from "./constants";
 import { getGlobalApi } from "./fakeBdApi";

--- a/src/plugins/bdCompatLayer/fileSystemViewer.tsx
+++ b/src/plugins/bdCompatLayer/fileSystemViewer.tsx
@@ -27,6 +27,9 @@ import { addCustomPlugin, convertPlugin } from "./pluginConstructor";
 import TreeView, { findInTree, TreeNode } from "./treeView";
 import { FSUtils, readdirPromise, reloadCompatLayer, ZIPUtils } from "./utils";
 
+import { FolderIcon, PlusIcon, RestartIcon } from "@components/Icons";
+import { QuickAction, QuickActionCard } from "@components/VencordSettings/quickActions";
+
 type SettingsPlugin = Plugin & {
     customSections: ((ID: Record<string, unknown>) => any)[];
 };
@@ -167,23 +170,14 @@ function makeTab() {
 
     return <SettingsTab title={TabName}>
         <Forms.FormSection title="File System Actions">
-            <Card className={cl("quick-actions-card")}>
-                <React.Fragment>
-                    <Button size={Button.Sizes.SMALL} onClick={() => ZIPUtils.downloadZip()}>
-                        Export Filesystem as ZIP
-                    </Button>
-                    <Button size={Button.Sizes.SMALL} onClick={() => ZIPUtils.importZip()}>
-                        Import Filesystem From ZIP
-                    </Button>
-                    <Button size={Button.Sizes.SMALL} onClick={() => reloadCompatLayer()}>
-                        Reload BD Plugins
-                    </Button>
-                    <Button size={Button.Sizes.SMALL} onClick={async () => await FSUtils.importFile("//BD/plugins", true, false, ".js")}>
-                        Import BD Plugin
-                    </Button>
-                    <Button size={Button.Sizes.SMALL} onClick={async () => await FSUtils.importFile("//BD/plugins", true, true, ".js")}>
-                        Import Bulk Plugins
-                    </Button>
+            <QuickActionCard>
+                <QuickAction text="Export Filesystem as ZIP" action={() => ZIPUtils.downloadZip()} Icon={FolderIcon}/>
+                <QuickAction text="Import Filesystem From ZIP" action={() => ZIPUtils.importZip()} Icon={FolderIcon}/>
+                <QuickAction text="Reload BD Plugins" action={() => reloadCompatLayer()} Icon={RestartIcon}/>
+                <QuickAction text="Import BD Plugin" action={async () => await FSUtils.importFile("//BD/plugins", true, false, ".js")} Icon={PlusIcon}/>
+                <QuickAction text="Import Bulk Plugins" action={async () => await FSUtils.importFile("//BD/plugins", true, true, ".js")} Icon={FolderIcon}/>
+            </QuickActionCard>
+                  <Card className={cl("quick-actions-card")}>
                     <Forms.FormText>Size of `/`: {
                         (() => {
                             try {
@@ -194,7 +188,6 @@ function makeTab() {
                             }
                         })()
                     } MB</Forms.FormText>
-                </React.Fragment>
             </Card>
         </Forms.FormSection>
         {/* <TreeView onContextMenu={contextMenuHandler} selectedNode={selectedNode} selectNode={handleNodeSelect} data={ */}


### PR DESCRIPTION
### Description of Changes
Update FileSystemViewer UI top-row button redesign to [better suit the layout Vencord has made](https://github.com/Vendicated/Vencord/commit/99b41dba1924f14241ed2a82ad7febfc3126f357).

Before:
![before](https://github.com/Davilarek/Vencord/assets/45422515/36b6746d-c6af-4ae8-af2e-e867439b7fb5)

After:
![after](https://github.com/Davilarek/Vencord/assets/45422515/55e547f5-6124-428e-af69-a50a038d8921)

### Rationale behind Changes
Vencord updated the button layout for the buttons atop both the Settings tab as well as Themes tab. This change is heavily inspired by the updates made in Vencord, and has the potential to allow custom icons to be used alongside the buttons in the redesign.

### Suggested Testing Steps
* Apply this PR as a [patch](https://patch-diff.githubusercontent.com/raw/Davilarek/Vencord/pull/19.patch), using something like `git apply --3way file.patch`,
* Recompile with the applied patch,
* Run Vencord, navigate to user settings → Virtual Filesystem,
* Observe the changes as indicated in screenshot,
* When content, run `git stash` in the source path and `git stash drop` or alternatively use `git checkout <HEAD/githash> -- src/plugins/bdCompatLayer/fileSystemViewer.tsx` to revert changes